### PR TITLE
Ctxt dist

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,6 +1,0 @@
----
-- name: Install pip
-  apt: name=python-pip update_cache=yes state=present
-
-- name: Install dependencies for docker management
-  pip: name=docker-py

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,8 +1,0 @@
----
-- name: Install pip
-  yum: name=python-pip state=latest
-  when: ansible_distribution_major_version|int >= 7
-
-- name: Install dependencies for docker management
-  pip: name=docker-py
-  when: ansible_distribution_major_version|int >= 7

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,3 @@
-- name: Include "{{ansible_os_family}}" tasks
-  include: "{{ansible_os_family}}.yml"
-
 - name: Create directory for the docker certs
   file:
     path: "/opt/docker_registry/certs"

--- a/tasks/wn.yml
+++ b/tasks/wn.yml
@@ -20,19 +20,21 @@
       - "/etc/docker/certs.d/{{front_hostname}}:5000/ca.crt"
 
   - name: Copy certificates from frontend
-    copy: 
+    fetch:
       src: "{{ item.src }}" 
       dest: "{{ item.dest }}"
+      flat: yes
     with_items:
       - src: "/opt/docker_registry/certs/{{front_hostname}}.cert"
         dest: "/opt/docker_registry/certs/{{front_hostname}}.cert"
       - src: "/opt/docker_registry/certs/{{front_hostname}}.key"
         dest: "/opt/docker_registry/certs/{{front_hostname}}.key"
-      - src: "/opt/docker_registry/certs/{{front_hostname}}.cert"
-        dest: "/etc/docker/certs.d/{{front_hostname}}:5000/{{front_hostname}}.cert"
-      - src: "/opt/docker_registry/certs/{{front_hostname}}.key"
-        dest: "/etc/docker/certs.d/{{front_hostname}}:5000/{{front_hostname}}.key"
-      - src: /opt/docker_registry/certs/ca.crt
-        dest: "/etc/docker/certs.d/{{front_hostname}}:5000/ca.crt"
+      - src: "/etc/docker/certs.d/{{front_hostname}}:5000/{{front_hostname}}.cert"
+        dest: "/opt/docker_registry/certs/{{front_hostname}}.cert"
+      - src: "/etc/docker/certs.d/{{front_hostname}}:5000/{{front_hostname}}.key"
+        dest: "/opt/docker_registry/certs/{{front_hostname}}.key"
+      - src: "/etc/docker/certs.d/{{front_hostname}}:5000/ca.crt"
+        dest: /opt/docker_registry/certs/ca.crt
+    delegate_to: '{{ front_hostname }}'
 
   when: (docker_installation == "registry") or (docker_installation == "both")

--- a/tasks/wn.yml
+++ b/tasks/wn.yml
@@ -7,6 +7,11 @@
     file:
       path: "/etc/docker/certs.d/{{front_hostname}}:5000/"
       state: directory
+  
+  - name: Modify permissions in certs directory for registry keys
+    file:
+      path: "/opt/docker_registry/certs/"
+      state: directory
       mode: 0757
 
   - name: Check and delete previous certificates

--- a/tasks/wn.yml
+++ b/tasks/wn.yml
@@ -7,6 +7,7 @@
     file:
       path: "/etc/docker/certs.d/{{front_hostname}}:5000/"
       state: directory
+      mode: 0757
 
   - name: Check and delete previous certificates
     file: 


### PR DESCRIPTION
Remove docker-py installation (is now in docker role) and change copy for fecth, that works with distributed contextualization of IM (and also with traditional).